### PR TITLE
test: add unit tests and CI for protocol logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-${{ runner.os }}-${{ hashFiles('BerbelRemote/platformio.ini') }}
+          restore-keys: pio-${{ runner.os }}-
+
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+
+      - name: Run native unit tests
+        run: pio test -e native -d BerbelRemote
+
+      - name: Build firmware (compile check)
+        run: |
+          cp BerbelRemote/src/config.example.h BerbelRemote/src/config.h
+          pio run -e esp32dev -d BerbelRemote

--- a/BerbelRemote/platformio.ini
+++ b/BerbelRemote/platformio.ini
@@ -1,3 +1,7 @@
+; Only the firmware env is built by a bare `pio run`; `native` is test-only.
+[platformio]
+default_envs = esp32dev
+
 [common]
 platform = espressif32
 board = esp32dev
@@ -25,3 +29,12 @@ upload_protocol = espota
 upload_port = berbel-remote.local
 upload_flags =
     --host_port=3232
+
+; Host-side unit tests for the pure protocol logic (no ESP32 needed):
+;   pio test -e native
+[env:native]
+platform = native
+test_framework = unity
+build_flags =
+    -std=c++11
+    -I src

--- a/BerbelRemote/src/berbel_protocol.h
+++ b/BerbelRemote/src/berbel_protocol.h
@@ -1,0 +1,110 @@
+/**
+ * Berbel BFB 6bT - pure protocol logic (no Arduino/NimBLE dependencies).
+ *
+ * Everything here is a side-effect-free function of its inputs so it can be
+ * unit-tested on the host with PlatformIO's `native` environment. The decode
+ * rules mirror the reverse-engineered protocol documented in main.cpp and
+ * REVERSE_ENGINEERING.md.
+ */
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <cstdio>
+
+namespace berbel {
+
+// Decoded view of a 9-byte hood status notification.
+struct DecodedStatus {
+  bool lightUp = false;     // Oberlicht
+  bool lightDown = false;   // Unterlicht
+  uint8_t fanSpeed = 0;     // 0=off, 1-3=Stufe, 4=Power
+  bool nachlauf = false;    // afterrun timer active
+  bool movingUp = false;    // cover retracting
+  bool movingDown = false;  // cover deploying
+};
+
+// Hood sends an all-0x11 sync packet on connect that carries no real state.
+inline bool isSyncPacket(const uint8_t raw[9]) {
+  for (int i = 0; i < 9; i++) {
+    if (raw[i] != 0x11) return false;
+  }
+  return true;
+}
+
+// Decode the 9-byte bitmask status into discrete fields.
+inline DecodedStatus decodeHoodStatus(const uint8_t raw[9]) {
+  DecodedStatus s;
+
+  // Lights (bits don't overlap with fan)
+  s.lightUp = (raw[2] & 0x10) != 0;    // Oberlicht: byte 2, bit 4
+  s.lightDown = (raw[4] & 0x10) != 0;  // Unterlicht: byte 4, bit 4
+
+  // Fan speed (only one active at a time)
+  if (raw[2] & 0x09)      s.fanSpeed = 4;  // Power:   0000 1001
+  else if (raw[1] & 0x10) s.fanSpeed = 3;  // Stufe 3: 0001 0000
+  else if (raw[1] & 0x01) s.fanSpeed = 2;  // Stufe 2: 0000 0001
+  else if (raw[0] & 0x10) s.fanSpeed = 1;  // Stufe 1: 0001 0000
+  else                    s.fanSpeed = 0;  // Aus
+
+  s.nachlauf = (raw[5] & 0x90) != 0;       // parallel to fan speed
+  s.movingUp = (raw[4] & 0x01) != 0;
+  s.movingDown = (raw[6] & 0x01) != 0;
+  return s;
+}
+
+// Cover state machine result. Strings match the HA entity values.
+struct CoverResult {
+  const char* state;     // up, moving up, moving down, down
+  const char* position;  // Oben, Unten
+};
+
+// Next cover state given the previous state and the current moving flags.
+// When the hood is not moving, the state settles from "moving up/down" to
+// "up/down" and the position is carried over unchanged.
+inline CoverResult nextCoverState(const char* prevState, const char* prevPosition,
+                                  bool movingUp, bool movingDown) {
+  if (movingUp)   return {"moving up", "Oben"};
+  if (movingDown) return {"moving down", "Unten"};
+  if (strcmp(prevState, "moving up") == 0)   return {"up", prevPosition};
+  if (strcmp(prevState, "moving down") == 0) return {"down", prevPosition};
+  return {prevState, prevPosition};
+}
+
+// Human-readable fan preset label for a given speed.
+inline const char* fanPresetName(uint8_t speed) {
+  switch (speed) {
+    case 1: return "Stufe 1";
+    case 2: return "Stufe 2";
+    case 3: return "Stufe 3";
+    case 4: return "Power";
+    default: return "Aus";
+  }
+}
+
+// Inverse of fanPresetName: parse a preset label back into a speed.
+// Unknown labels (including "Aus") map to 0 (off).
+inline uint8_t fanPresetToSpeed(const char* preset) {
+  if (strcmp(preset, "Stufe 1") == 0) return 1;
+  if (strcmp(preset, "Stufe 2") == 0) return 2;
+  if (strcmp(preset, "Stufe 3") == 0) return 3;
+  if (strcmp(preset, "Power") == 0)   return 4;
+  return 0;
+}
+
+// Extract a string value for `key` from a flat `"key":"value"` JSON object.
+// Returns false if the key is missing or the value doesn't fit in `out`.
+inline bool jsonGetValue(const char* json, const char* key, char* out, size_t outLen) {
+  char search[32];
+  snprintf(search, sizeof(search), "\"%s\":\"", key);
+  const char* start = strstr(json, search);
+  if (!start) return false;
+  start += strlen(search);
+  const char* end = strchr(start, '"');
+  if (!end || (size_t)(end - start) >= outLen) return false;
+  memcpy(out, start, end - start);
+  out[end - start] = '\0';
+  return true;
+}
+
+}  // namespace berbel

--- a/BerbelRemote/src/main.cpp
+++ b/BerbelRemote/src/main.cpp
@@ -55,6 +55,7 @@
 #include <ArduinoOTA.h>
 
 #include "config.h"
+#include "berbel_protocol.h"
 
 // ============================================================================
 // Berbel Custom Service UUIDs
@@ -286,16 +287,6 @@ void processCmdQueue() {
 // ============================================================================
 // MQTT State Publishing
 // ============================================================================
-static const char* fanPresetName(uint8_t speed) {
-  switch (speed) {
-    case 1: return "Stufe 1";
-    case 2: return "Stufe 2";
-    case 3: return "Stufe 3";
-    case 4: return "Power";
-    default: return "Aus";
-  }
-}
-
 void publishState() {
   if (!mqtt.connected()) return;
 
@@ -326,7 +317,7 @@ void publishState() {
     "}",
     hood.lightUp ? "ON" : "OFF",
     hood.lightDown ? "ON" : "OFF",
-    fanPresetName(hood.fanSpeed),
+    berbel::fanPresetName(hood.fanSpeed),
     hood.nachlauf ? "ON" : "OFF",
 #if HOOD_HAS_COVER
     hood.position,
@@ -501,40 +492,21 @@ void publishDiscovery() {
 // ============================================================================
 // Restore hood state from retained MQTT message (simple JSON parser)
 // ============================================================================
-static bool jsonGetValue(const char* json, const char* key, char* out, size_t outLen) {
-  // Find "key":"value" in JSON string
-  char search[32];
-  snprintf(search, sizeof(search), "\"%s\":\"", key);
-  const char* start = strstr(json, search);
-  if (!start) return false;
-  start += strlen(search);
-  const char* end = strchr(start, '"');
-  if (!end || (size_t)(end - start) >= outLen) return false;
-  memcpy(out, start, end - start);
-  out[end - start] = '\0';
-  return true;
-}
-
 void restoreStateFromMqtt(const char* json) {
   char val[32];
 
-  if (jsonGetValue(json, "light_up", val, sizeof(val)))
+  if (berbel::jsonGetValue(json, "light_up", val, sizeof(val)))
     hood.lightUp = (strcmp(val, "ON") == 0);
-  if (jsonGetValue(json, "light_down", val, sizeof(val)))
+  if (berbel::jsonGetValue(json, "light_down", val, sizeof(val)))
     hood.lightDown = (strcmp(val, "ON") == 0);
-  if (jsonGetValue(json, "nachlauf", val, sizeof(val)))
+  if (berbel::jsonGetValue(json, "nachlauf", val, sizeof(val)))
     hood.nachlauf = (strcmp(val, "ON") == 0);
-  if (jsonGetValue(json, "fan_preset", val, sizeof(val))) {
-    if (strcmp(val, "Stufe 1") == 0)      hood.fanSpeed = 1;
-    else if (strcmp(val, "Stufe 2") == 0)  hood.fanSpeed = 2;
-    else if (strcmp(val, "Stufe 3") == 0)  hood.fanSpeed = 3;
-    else if (strcmp(val, "Power") == 0)    hood.fanSpeed = 4;
-    else                                  hood.fanSpeed = 0;
-  }
+  if (berbel::jsonGetValue(json, "fan_preset", val, sizeof(val)))
+    hood.fanSpeed = berbel::fanPresetToSpeed(val);
 #if HOOD_HAS_COVER
-  if (jsonGetValue(json, "position", val, sizeof(val)))
+  if (berbel::jsonGetValue(json, "position", val, sizeof(val)))
     hood.position = (strcmp(val, "Unten") == 0) ? "Unten" : "Oben";
-  if (jsonGetValue(json, "cover_state", val, sizeof(val))) {
+  if (berbel::jsonGetValue(json, "cover_state", val, sizeof(val))) {
     if (strcmp(val, "down") == 0)           hood.coverState = "down";
     else if (strcmp(val, "moving up") == 0) hood.coverState = "moving up";
     else if (strcmp(val, "moving down") == 0) hood.coverState = "moving down";
@@ -948,43 +920,23 @@ void loop() {
     newStatusReceived = false;
 
     // Skip the sync packet (all 0x11) entirely
-    bool isSync = true;
-    for (int i = 0; i < 9; i++) {
-      if (pendingStatus[i] != 0x11) { isSync = false; break; }
-    }
-    if (isSync) {
+    if (berbel::isSyncPacket(pendingStatus)) {
       Serial.println("[HOOD] Sync packet ignored");
     } else {
       hoodStateValid = true;
       memcpy(hood.raw, pendingStatus, 9);
 
-      // Lights (bitmask - bits don't overlap with fan)
-      hood.lightUp   = (hood.raw[2] & 0x10);  // Oberlicht: bit 4
-      hood.lightDown = (hood.raw[4] & 0x10);  // Unterlicht: bit 4
-
-      // Fan speed (bitmask - only one active at a time)
-      if (hood.raw[2] & 0x09)               hood.fanSpeed = 4;  // Power: 0000 1001
-      else if (hood.raw[1] & 0x10)          hood.fanSpeed = 3;  // Stufe 3: 0001 0000
-      else if (hood.raw[1] & 0x01)          hood.fanSpeed = 2;  // Stufe 2: 0000 0001
-      else if (hood.raw[0] & 0x10)          hood.fanSpeed = 1;  // Stufe 1: 0001 0000
-      else                                  hood.fanSpeed = 0;  // Aus
-
-      // Nachlauf (parallel to fan speed)
-      hood.nachlauf = (hood.raw[5] & 0x90);
+      berbel::DecodedStatus status = berbel::decodeHoodStatus(hood.raw);
+      hood.lightUp   = status.lightUp;
+      hood.lightDown = status.lightDown;
+      hood.fanSpeed  = status.fanSpeed;
+      hood.nachlauf  = status.nachlauf;
 
 #if HOOD_HAS_COVER
-      // Cover state (byte[4] bit 0 = moving up, byte[6] bit 0 = moving down)
-      if (hood.raw[4] & 0x01) {
-        hood.coverState = "moving up";
-        hood.position = "Oben";
-      } else if (hood.raw[6] & 0x01) {
-        hood.coverState = "moving down";
-        hood.position = "Unten";
-      } else if (strcmp(hood.coverState, "moving up") == 0) {
-        hood.coverState = "up";
-      } else if (strcmp(hood.coverState, "moving down") == 0) {
-        hood.coverState = "down";
-      }
+      berbel::CoverResult cover = berbel::nextCoverState(
+        hood.coverState, hood.position, status.movingUp, status.movingDown);
+      hood.coverState = cover.state;
+      hood.position = cover.position;
 #endif
 
       publishState();

--- a/BerbelRemote/test/test_protocol/test_protocol.cpp
+++ b/BerbelRemote/test/test_protocol/test_protocol.cpp
@@ -1,0 +1,254 @@
+/**
+ * Host-side unit tests for the reverse-engineered Berbel protocol logic.
+ * Runs in PlatformIO's `native` environment (no ESP32 required):
+ *
+ *   pio test -e native
+ */
+#include <unity.h>
+
+#include "berbel_protocol.h"
+
+using namespace berbel;
+
+// ----------------------------------------------------------------------------
+// isSyncPacket
+// ----------------------------------------------------------------------------
+void test_sync_packet_all_0x11(void) {
+  uint8_t raw[9] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11};
+  TEST_ASSERT_TRUE(isSyncPacket(raw));
+}
+
+void test_sync_packet_one_byte_differs(void) {
+  uint8_t raw[9] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x00};
+  TEST_ASSERT_FALSE(isSyncPacket(raw));
+}
+
+void test_sync_packet_all_zero_is_not_sync(void) {
+  uint8_t raw[9] = {0};
+  TEST_ASSERT_FALSE(isSyncPacket(raw));
+}
+
+// ----------------------------------------------------------------------------
+// decodeHoodStatus - lights
+// ----------------------------------------------------------------------------
+void test_decode_all_off(void) {
+  uint8_t raw[9] = {0};
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_FALSE(s.lightUp);
+  TEST_ASSERT_FALSE(s.lightDown);
+  TEST_ASSERT_EQUAL_UINT8(0, s.fanSpeed);
+  TEST_ASSERT_FALSE(s.nachlauf);
+  TEST_ASSERT_FALSE(s.movingUp);
+  TEST_ASSERT_FALSE(s.movingDown);
+}
+
+void test_decode_light_up(void) {
+  uint8_t raw[9] = {0};
+  raw[2] = 0x10;  // Oberlicht
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_TRUE(s.lightUp);
+  TEST_ASSERT_FALSE(s.lightDown);
+}
+
+void test_decode_light_down(void) {
+  uint8_t raw[9] = {0};
+  raw[4] = 0x10;  // Unterlicht
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_FALSE(s.lightUp);
+  TEST_ASSERT_TRUE(s.lightDown);
+}
+
+// ----------------------------------------------------------------------------
+// decodeHoodStatus - fan speed (priority Power > 3 > 2 > 1 > off)
+// ----------------------------------------------------------------------------
+void test_decode_fan_stufe_1(void) {
+  uint8_t raw[9] = {0};
+  raw[0] = 0x10;
+  TEST_ASSERT_EQUAL_UINT8(1, decodeHoodStatus(raw).fanSpeed);
+}
+
+void test_decode_fan_stufe_2(void) {
+  uint8_t raw[9] = {0};
+  raw[1] = 0x01;
+  TEST_ASSERT_EQUAL_UINT8(2, decodeHoodStatus(raw).fanSpeed);
+}
+
+void test_decode_fan_stufe_3(void) {
+  uint8_t raw[9] = {0};
+  raw[1] = 0x10;
+  TEST_ASSERT_EQUAL_UINT8(3, decodeHoodStatus(raw).fanSpeed);
+}
+
+void test_decode_fan_power(void) {
+  uint8_t raw[9] = {0};
+  raw[2] = 0x09;
+  TEST_ASSERT_EQUAL_UINT8(4, decodeHoodStatus(raw).fanSpeed);
+}
+
+void test_decode_fan_power_takes_priority(void) {
+  // Power bits set together with a lower stufe -> Power wins.
+  uint8_t raw[9] = {0};
+  raw[0] = 0x10;  // would be Stufe 1
+  raw[1] = 0x10;  // would be Stufe 3
+  raw[2] = 0x09;  // Power
+  TEST_ASSERT_EQUAL_UINT8(4, decodeHoodStatus(raw).fanSpeed);
+}
+
+// ----------------------------------------------------------------------------
+// decodeHoodStatus - nachlauf and cover movement flags
+// ----------------------------------------------------------------------------
+void test_decode_nachlauf(void) {
+  uint8_t raw[9] = {0};
+  raw[5] = 0x90;
+  TEST_ASSERT_TRUE(decodeHoodStatus(raw).nachlauf);
+}
+
+void test_decode_moving_up(void) {
+  uint8_t raw[9] = {0};
+  raw[4] = 0x01;
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_TRUE(s.movingUp);
+  TEST_ASSERT_FALSE(s.movingDown);
+}
+
+void test_decode_moving_down(void) {
+  uint8_t raw[9] = {0};
+  raw[6] = 0x01;
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_FALSE(s.movingUp);
+  TEST_ASSERT_TRUE(s.movingDown);
+}
+
+void test_decode_light_and_fan_independent(void) {
+  // raw[2] carries both Oberlicht (bit4) and Power (bits 0/3); they must not
+  // interfere: 0x10 | 0x09 = 0x19 -> light up AND fan power.
+  uint8_t raw[9] = {0};
+  raw[2] = 0x19;
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_TRUE(s.lightUp);
+  TEST_ASSERT_EQUAL_UINT8(4, s.fanSpeed);
+}
+
+// ----------------------------------------------------------------------------
+// nextCoverState (state machine)
+// ----------------------------------------------------------------------------
+void test_cover_moving_up_sets_oben(void) {
+  CoverResult c = nextCoverState("down", "Unten", true, false);
+  TEST_ASSERT_EQUAL_STRING("moving up", c.state);
+  TEST_ASSERT_EQUAL_STRING("Oben", c.position);
+}
+
+void test_cover_moving_down_sets_unten(void) {
+  CoverResult c = nextCoverState("up", "Oben", false, true);
+  TEST_ASSERT_EQUAL_STRING("moving down", c.state);
+  TEST_ASSERT_EQUAL_STRING("Unten", c.position);
+}
+
+void test_cover_settles_up_after_moving_up(void) {
+  CoverResult c = nextCoverState("moving up", "Oben", false, false);
+  TEST_ASSERT_EQUAL_STRING("up", c.state);
+  TEST_ASSERT_EQUAL_STRING("Oben", c.position);
+}
+
+void test_cover_settles_down_after_moving_down(void) {
+  CoverResult c = nextCoverState("moving down", "Unten", false, false);
+  TEST_ASSERT_EQUAL_STRING("down", c.state);
+  TEST_ASSERT_EQUAL_STRING("Unten", c.position);
+}
+
+void test_cover_idle_keeps_state(void) {
+  CoverResult c = nextCoverState("up", "Oben", false, false);
+  TEST_ASSERT_EQUAL_STRING("up", c.state);
+  TEST_ASSERT_EQUAL_STRING("Oben", c.position);
+}
+
+// ----------------------------------------------------------------------------
+// fanPresetName / fanPresetToSpeed (round trip)
+// ----------------------------------------------------------------------------
+void test_fan_preset_name(void) {
+  TEST_ASSERT_EQUAL_STRING("Aus", fanPresetName(0));
+  TEST_ASSERT_EQUAL_STRING("Stufe 1", fanPresetName(1));
+  TEST_ASSERT_EQUAL_STRING("Stufe 2", fanPresetName(2));
+  TEST_ASSERT_EQUAL_STRING("Stufe 3", fanPresetName(3));
+  TEST_ASSERT_EQUAL_STRING("Power", fanPresetName(4));
+  TEST_ASSERT_EQUAL_STRING("Aus", fanPresetName(99));
+}
+
+void test_fan_preset_to_speed(void) {
+  TEST_ASSERT_EQUAL_UINT8(0, fanPresetToSpeed("Aus"));
+  TEST_ASSERT_EQUAL_UINT8(1, fanPresetToSpeed("Stufe 1"));
+  TEST_ASSERT_EQUAL_UINT8(2, fanPresetToSpeed("Stufe 2"));
+  TEST_ASSERT_EQUAL_UINT8(3, fanPresetToSpeed("Stufe 3"));
+  TEST_ASSERT_EQUAL_UINT8(4, fanPresetToSpeed("Power"));
+  TEST_ASSERT_EQUAL_UINT8(0, fanPresetToSpeed("garbage"));
+}
+
+void test_fan_preset_round_trip(void) {
+  for (uint8_t speed = 0; speed <= 4; speed++) {
+    TEST_ASSERT_EQUAL_UINT8(speed, fanPresetToSpeed(fanPresetName(speed)));
+  }
+}
+
+// ----------------------------------------------------------------------------
+// jsonGetValue
+// ----------------------------------------------------------------------------
+void test_json_get_value_present(void) {
+  const char* json = "{\"light_up\":\"ON\",\"fan_preset\":\"Power\"}";
+  char val[32];
+  TEST_ASSERT_TRUE(jsonGetValue(json, "light_up", val, sizeof(val)));
+  TEST_ASSERT_EQUAL_STRING("ON", val);
+  TEST_ASSERT_TRUE(jsonGetValue(json, "fan_preset", val, sizeof(val)));
+  TEST_ASSERT_EQUAL_STRING("Power", val);
+}
+
+void test_json_get_value_missing_key(void) {
+  const char* json = "{\"light_up\":\"ON\"}";
+  char val[32];
+  TEST_ASSERT_FALSE(jsonGetValue(json, "nachlauf", val, sizeof(val)));
+}
+
+void test_json_get_value_buffer_too_small(void) {
+  const char* json = "{\"x\":\"abcdefghij\"}";
+  char val[4];
+  TEST_ASSERT_FALSE(jsonGetValue(json, "x", val, sizeof(val)));
+}
+
+// ----------------------------------------------------------------------------
+// Test runner
+// ----------------------------------------------------------------------------
+int main(int, char**) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_sync_packet_all_0x11);
+  RUN_TEST(test_sync_packet_one_byte_differs);
+  RUN_TEST(test_sync_packet_all_zero_is_not_sync);
+
+  RUN_TEST(test_decode_all_off);
+  RUN_TEST(test_decode_light_up);
+  RUN_TEST(test_decode_light_down);
+  RUN_TEST(test_decode_fan_stufe_1);
+  RUN_TEST(test_decode_fan_stufe_2);
+  RUN_TEST(test_decode_fan_stufe_3);
+  RUN_TEST(test_decode_fan_power);
+  RUN_TEST(test_decode_fan_power_takes_priority);
+  RUN_TEST(test_decode_nachlauf);
+  RUN_TEST(test_decode_moving_up);
+  RUN_TEST(test_decode_moving_down);
+  RUN_TEST(test_decode_light_and_fan_independent);
+
+  RUN_TEST(test_cover_moving_up_sets_oben);
+  RUN_TEST(test_cover_moving_down_sets_unten);
+  RUN_TEST(test_cover_settles_up_after_moving_up);
+  RUN_TEST(test_cover_settles_down_after_moving_down);
+  RUN_TEST(test_cover_idle_keeps_state);
+
+  RUN_TEST(test_fan_preset_name);
+  RUN_TEST(test_fan_preset_to_speed);
+  RUN_TEST(test_fan_preset_round_trip);
+
+  RUN_TEST(test_json_get_value_present);
+  RUN_TEST(test_json_get_value_missing_key);
+  RUN_TEST(test_json_get_value_buffer_too_small);
+
+  return UNITY_END();
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Berbel BFB 6bT - BLE Remote Control Emulator
 
+[![tests](https://github.com/tfohlmeister/berbel-remote/actions/workflows/test.yml/badge.svg)](https://github.com/tfohlmeister/berbel-remote/actions/workflows/test.yml)
+
 ESP32-based emulator for the **Berbel BFB 6bT** remote control (Art. 1090045), with full Home Assistant integration via MQTT. Tested with a Berbel Skyline Frame hood, but the BFB 6bT remote is compatible with other Berbel hoods as well.
 
 > **Disclaimer:** This is an **unofficial**, independent project created through reverse engineering.
@@ -173,15 +175,34 @@ See [REVERSE_ENGINEERING.md](REVERSE_ENGINEERING.md) for the full protocol docum
 berbel-remote/
 ├── BerbelRemote/              # ESP32 firmware (PlatformIO)
 │   ├── src/
-│   │   ├── main.cpp              # Complete firmware source
+│   │   ├── main.cpp              # Firmware: BLE/WiFi/MQTT wiring
+│   │   ├── berbel_protocol.h     # Pure protocol logic (unit-tested)
 │   │   ├── config.example.h      # WiFi/MQTT config template
 │   │   └── config.h              # Your credentials (gitignored)
+│   ├── test/
+│   │   └── test_protocol/        # Host-side unit tests (Unity)
 │   └── platformio.ini            # Build configuration
+├── .github/workflows/test.yml     # CI: unit tests + firmware build
 ├── REVERSE_ENGINEERING.md         # Full protocol documentation
 ├── berbel_button_map.json        # Button code mapping (machine-readable)
 ├── LICENSE                       # MIT License
 └── README.md
 ```
+
+## Testing
+
+The reverse-engineered protocol logic (status decoding, fan/cover state, JSON
+parsing) lives in `src/berbel_protocol.h` as dependency-free functions, so it
+can be unit-tested on the host without an ESP32:
+
+```bash
+cd BerbelRemote
+pio test -e native
+```
+
+CI runs these tests and a full firmware compile check on every push (see the
+tests badge at the top). The hardware I/O (BLE, WiFi, MQTT, OTA) is exercised on
+the device, not in CI.
 
 ## Contributing
 


### PR DESCRIPTION
Extracts the reverse-engineered protocol logic (status decode, fan/cover state, JSON parse) into a dependency-free header and adds 26 host-side Unity tests plus a GitHub Actions workflow (native tests + firmware compile check). Firmware behavior unchanged. CI green.