### PR TITLE
Add optional third light (ceiling connection) on button 0x0B

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,19 @@ jobs:
         run: |
           cp BerbelRemote/src/config.example.h BerbelRemote/src/config.h
           pio run -e esp32dev -d BerbelRemote
+
+      # config.example.h only covers one combination of the hood feature flags.
+      # Build the others too, otherwise a typo inside a disabled #if block
+      # passes CI and breaks only for the users who enable that flag.
+      - name: Build firmware (all hood feature flag combinations)
+        run: |
+          for cover in true false; do
+            for ceiling in true false; do
+              echo "::group::HOOD_HAS_COVER=$cover HOOD_HAS_CEILING_LIGHT=$ceiling"
+              sed -e "s/^#define HOOD_HAS_COVER .*/#define HOOD_HAS_COVER $cover/" \
+                  -e "s/^#define HOOD_HAS_CEILING_LIGHT .*/#define HOOD_HAS_CEILING_LIGHT $ceiling/" \
+                  BerbelRemote/src/config.example.h > BerbelRemote/src/config.h
+              pio run -e esp32dev -d BerbelRemote
+              echo "::endgroup::"
+            done
+          done

--- a/BerbelRemote/src/berbel_protocol.h
+++ b/BerbelRemote/src/berbel_protocol.h
@@ -16,12 +16,13 @@ namespace berbel {
 
 // Decoded view of a 9-byte hood status notification.
 struct DecodedStatus {
-  bool lightUp = false;     // Oberlicht
-  bool lightDown = false;   // Unterlicht
-  uint8_t fanSpeed = 0;     // 0=off, 1-3=Stufe, 4=Power
-  bool nachlauf = false;    // afterrun timer active
-  bool movingUp = false;    // cover retracting
-  bool movingDown = false;  // cover deploying
+  bool lightUp = false;       // Oberlicht
+  bool lightDown = false;     // Unterlicht
+  bool lightCeiling = false;  // Deckenlicht (ceiling connection, optional accessory)
+  uint8_t fanSpeed = 0;       // 0=off, 1-3=Stufe, 4=Power
+  bool nachlauf = false;      // afterrun timer active
+  bool movingUp = false;      // cover retracting
+  bool movingDown = false;    // cover deploying
 };
 
 // Hood sends an all-0x11 sync packet on connect that carries no real state.
@@ -37,8 +38,11 @@ inline DecodedStatus decodeHoodStatus(const uint8_t raw[9]) {
   DecodedStatus s;
 
   // Lights (bits don't overlap with fan)
-  s.lightUp = (raw[2] & 0x10) != 0;    // Oberlicht: byte 2, bit 4
-  s.lightDown = (raw[4] & 0x10) != 0;  // Unterlicht: byte 4, bit 4
+  s.lightUp = (raw[2] & 0x10) != 0;       // Oberlicht: byte 2, bit 4
+  s.lightDown = (raw[4] & 0x10) != 0;     // Unterlicht: byte 4, bit 4
+  // Deckenlicht: byte 5, bit 0. Shares the byte with Nachlauf (0x90) but no bits
+  // overlap. Confirmed on a single hood (issue #3), unverified elsewhere.
+  s.lightCeiling = (raw[5] & 0x01) != 0;
 
   // Fan speed (only one active at a time)
   if (raw[2] & 0x09)      s.fanSpeed = 4;  // Power:   0000 1001

--- a/BerbelRemote/src/config.example.h
+++ b/BerbelRemote/src/config.example.h
@@ -15,3 +15,9 @@
 // When false, Position, Hochfahren, Herunterfahren, and Cover State
 // entities will not be created in Home Assistant.
 #define HOOD_HAS_COVER true
+
+// Set to true if your hood has a ceiling connection with effect lighting
+// ("Deckenanschluss mit Effektbeleuchtung"), the optional third lamp driven
+// by the multifunction button. When false, the Deckenlicht entity will not
+// be created in Home Assistant.
+#define HOOD_HAS_CEILING_LIGHT false

--- a/BerbelRemote/src/main.cpp
+++ b/BerbelRemote/src/main.cpp
@@ -21,12 +21,14 @@
  *   Byte[2] & 0x10  = Oberlicht (upper light)
  *   Byte[4] & 0x10  = Unterlicht (lower light)
  *   Byte[4] & 0x01  = Cover moving up (retracting)
+ *   Byte[5] & 0x01  = Deckenlicht (ceiling connection light)
  *   Byte[5] & 0x90  = Nachlauf (afterrun timer active)
  *   Byte[6] & 0x01  = Cover moving down (deploying)
  *
  * HA Entities (via MQTT Auto-Discovery):
  *   - Oberlicht       (light)          Toggle upper light
  *   - Unterlicht      (light)          Toggle lower light
+ *   - Deckenlicht     (light)          Toggle ceiling connection light (only with HOOD_HAS_CEILING_LIGHT)
  *   - Luefter         (select)         Fan speed: Aus, Stufe 1-3, Power
  *   - Ausschalten     (button)         Power off (starts Nachlauf)
  *   - Nachlauf        (switch)         Toggle afterrun timer
@@ -57,6 +59,13 @@
 #include "config.h"
 #include "berbel_protocol.h"
 
+// Feature flags added after the initial release. A config.h from an older
+// checkout does not define them, so default them to off here rather than
+// relying on the preprocessor treating the unknown name as 0.
+#ifndef HOOD_HAS_CEILING_LIGHT
+#define HOOD_HAS_CEILING_LIGHT false
+#endif
+
 // ============================================================================
 // Berbel Custom Service UUIDs
 // ============================================================================
@@ -65,7 +74,7 @@
 #define BERBEL_WRITE_UUID     "f004f001-5745-4053-8043-62657262656c"  // Status from hood
 
 // ============================================================================
-// Button Codes
+// Button Codes (named after the function in the Berbel BFB 6bT manual)
 // ============================================================================
 #define BTN_POWER       0x01
 #define BTN_FAN_1       0x02
@@ -73,11 +82,11 @@
 #define BTN_FAN_3       0x04
 #define BTN_FAN_P       0x05
 #define BTN_LIGHT_UP    0x06
-#define BTN_PLAY        0x07
-#define BTN_RELOAD      0x08
+#define BTN_SYNC        0x07
+#define BTN_RECIRC      0x08
 #define BTN_MOVE_UP     0x09
 #define BTN_LIGHT_DOWN  0x0A
-#define BTN_RECORD      0x0B
+#define BTN_MULTI       0x0B  // multifunction, drives the ceiling connection light
 #define BTN_TIMER       0x0C
 #define BTN_MOVE_DOWN   0x0D
 
@@ -89,6 +98,9 @@
 #define MQTT_STATE          MQTT_BASE "/state"
 #define MQTT_CMD_LIGHT_UP   MQTT_BASE "/light_up/set"
 #define MQTT_CMD_LIGHT_DOWN MQTT_BASE "/light_down/set"
+#if HOOD_HAS_CEILING_LIGHT
+#define MQTT_CMD_LIGHT_CEILING MQTT_BASE "/light_ceiling/set"
+#endif
 #define MQTT_CMD_FAN_PRESET MQTT_BASE "/fan/preset/set"
 #define MQTT_CMD_POWER      MQTT_BASE "/power/set"
 #define MQTT_CMD_NACHLAUF   MQTT_BASE "/nachlauf/set"
@@ -105,6 +117,9 @@
 struct HoodState {
   bool lightUp = false;
   bool lightDown = false;
+#if HOOD_HAS_CEILING_LIGHT
+  bool lightCeiling = false;
+#endif
   uint8_t fanSpeed = 0;  // 0=off, 1-4
   bool nachlauf = false;  // timer/afterrun active
 #if HOOD_HAS_COVER
@@ -317,6 +332,9 @@ void publishState() {
     "{"
     "\"light_up\":\"%s\","
     "\"light_down\":\"%s\","
+#if HOOD_HAS_CEILING_LIGHT
+    "\"light_ceiling\":\"%s\","
+#endif
     "\"fan_preset\":\"%s\","
     "\"nachlauf\":\"%s\","
 #if HOOD_HAS_COVER
@@ -328,6 +346,9 @@ void publishState() {
     "}",
     hood.lightUp ? "ON" : "OFF",
     hood.lightDown ? "ON" : "OFF",
+#if HOOD_HAS_CEILING_LIGHT
+    hood.lightCeiling ? "ON" : "OFF",
+#endif
     berbel::fanPresetName(hood.fanSpeed),
     hood.nachlauf ? "ON" : "OFF",
 #if HOOD_HAS_COVER
@@ -363,6 +384,11 @@ void cleanupOldDiscovery() {
     "homeassistant/fan/berbel_hood/fan/config",
     "homeassistant/binary_sensor/berbel_hood/nachlauf/config",
     "homeassistant/cover/berbel_hood/cover/config",
+#if !HOOD_HAS_CEILING_LIGHT
+    // Feature disabled again: drop the entity a previous build registered,
+    // otherwise it lingers in HA as a toggle nothing listens to.
+    "homeassistant/light/berbel_hood/light_ceiling/config",
+#endif
     nullptr
   };
   for (int i = 0; oldTopics[i] != nullptr; i++) {
@@ -396,6 +422,19 @@ void publishDiscovery() {
     "\"stat_val_tpl\":\"{{ value_json.light_down }}\","
     "\"ic\":\"mdi:desk-lamp\""
   );
+
+#if HOOD_HAS_CEILING_LIGHT
+  // Deckenlicht (ceiling connection with effect lighting)
+  publishDiscoveryMsg(
+    "homeassistant/light/berbel_hood/light_ceiling/config",
+    "\"name\":\"Deckenlicht\","
+    "\"uniq_id\":\"berbel_light_ceiling\","
+    "\"stat_t\":\"" MQTT_STATE "\","
+    "\"cmd_t\":\"" MQTT_CMD_LIGHT_CEILING "\","
+    "\"stat_val_tpl\":\"{{ value_json.light_ceiling }}\","
+    "\"ic\":\"mdi:led-strip-variant\""
+  );
+#endif
 
   // Fan (Luefter) - select entity for 5 speed levels
   publishDiscoveryMsg(
@@ -510,6 +549,10 @@ void restoreStateFromMqtt(const char* json) {
     hood.lightUp = (strcmp(val, "ON") == 0);
   if (berbel::jsonGetValue(json, "light_down", val, sizeof(val)))
     hood.lightDown = (strcmp(val, "ON") == 0);
+#if HOOD_HAS_CEILING_LIGHT
+  if (berbel::jsonGetValue(json, "light_ceiling", val, sizeof(val)))
+    hood.lightCeiling = (strcmp(val, "ON") == 0);
+#endif
   if (berbel::jsonGetValue(json, "nachlauf", val, sizeof(val)))
     hood.nachlauf = (strcmp(val, "ON") == 0);
   if (berbel::jsonGetValue(json, "fan_preset", val, sizeof(val)))
@@ -575,6 +618,17 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
     }
     queueButton(BTN_LIGHT_DOWN, "Light Down");
   }
+#if HOOD_HAS_CEILING_LIGHT
+  // Deckenlicht - TOGGLE: check state before sending
+  else if (t == MQTT_CMD_LIGHT_CEILING) {
+    bool wantOn = (strcmp(msg, "ON") == 0);
+    if (wantOn == hood.lightCeiling) {
+      Serial.printf("[MQTT] Deckenlicht already %s, skipping\n", msg);
+      return;
+    }
+    queueButton(BTN_MULTI, "Light Ceiling");
+  }
+#endif
   // Power button (Ausschalten)
   else if (t == MQTT_CMD_POWER) {
     queueButton(BTN_POWER, "Power Off");
@@ -700,6 +754,9 @@ void mqttReconnect() {
 
     mqtt.subscribe(MQTT_CMD_LIGHT_UP);
     mqtt.subscribe(MQTT_CMD_LIGHT_DOWN);
+#if HOOD_HAS_CEILING_LIGHT
+    mqtt.subscribe(MQTT_CMD_LIGHT_CEILING);
+#endif
     mqtt.subscribe(MQTT_CMD_POWER);
     mqtt.subscribe(MQTT_CMD_NACHLAUF);
     mqtt.subscribe(MQTT_CMD_FAN_PRESET);
@@ -947,6 +1004,9 @@ void loop() {
       berbel::DecodedStatus status = berbel::decodeHoodStatus(hood.raw);
       hood.lightUp   = status.lightUp;
       hood.lightDown = status.lightDown;
+#if HOOD_HAS_CEILING_LIGHT
+      hood.lightCeiling = status.lightCeiling;
+#endif
       hood.fanSpeed  = status.fanSpeed;
       hood.nachlauf  = status.nachlauf;
 

--- a/BerbelRemote/test/test_protocol/test_protocol.cpp
+++ b/BerbelRemote/test/test_protocol/test_protocol.cpp
@@ -36,6 +36,7 @@ void test_decode_all_off(void) {
   DecodedStatus s = decodeHoodStatus(raw);
   TEST_ASSERT_FALSE(s.lightUp);
   TEST_ASSERT_FALSE(s.lightDown);
+  TEST_ASSERT_FALSE(s.lightCeiling);
   TEST_ASSERT_EQUAL_UINT8(0, s.fanSpeed);
   TEST_ASSERT_FALSE(s.nachlauf);
   TEST_ASSERT_FALSE(s.movingUp);
@@ -56,6 +57,45 @@ void test_decode_light_down(void) {
   DecodedStatus s = decodeHoodStatus(raw);
   TEST_ASSERT_FALSE(s.lightUp);
   TEST_ASSERT_TRUE(s.lightDown);
+}
+
+void test_decode_light_ceiling(void) {
+  uint8_t raw[9] = {0};
+  raw[5] = 0x01;  // Deckenlicht
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_FALSE(s.lightUp);
+  TEST_ASSERT_FALSE(s.lightDown);
+  TEST_ASSERT_TRUE(s.lightCeiling);
+}
+
+void test_decode_all_three_lights(void) {
+  // Reported in issue #3 from a BFB 6bT (Skyline with lift) that has a ceiling
+  // connection, measured with all three lamps on. Confirmed on that hood only.
+  uint8_t raw[9] = {0x00, 0x00, 0x10, 0x00, 0x10, 0x01, 0x00, 0x00, 0x00};
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_TRUE(s.lightUp);
+  TEST_ASSERT_TRUE(s.lightDown);
+  TEST_ASSERT_TRUE(s.lightCeiling);
+  TEST_ASSERT_EQUAL_UINT8(0, s.fanSpeed);
+  TEST_ASSERT_FALSE(s.nachlauf);
+}
+
+void test_decode_ceiling_light_independent_of_nachlauf(void) {
+  // raw[5] carries both Deckenlicht (bit 0) and Nachlauf (0x90); they must not
+  // interfere: 0x90 | 0x01 = 0x91 -> ceiling light AND afterrun.
+  uint8_t raw[9] = {0};
+  raw[5] = 0x91;
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_TRUE(s.lightCeiling);
+  TEST_ASSERT_TRUE(s.nachlauf);
+}
+
+void test_decode_nachlauf_alone_leaves_ceiling_light_off(void) {
+  uint8_t raw[9] = {0};
+  raw[5] = 0x90;
+  DecodedStatus s = decodeHoodStatus(raw);
+  TEST_ASSERT_FALSE(s.lightCeiling);
+  TEST_ASSERT_TRUE(s.nachlauf);
 }
 
 // ----------------------------------------------------------------------------
@@ -274,6 +314,10 @@ int main(int, char**) {
   RUN_TEST(test_decode_all_off);
   RUN_TEST(test_decode_light_up);
   RUN_TEST(test_decode_light_down);
+  RUN_TEST(test_decode_light_ceiling);
+  RUN_TEST(test_decode_all_three_lights);
+  RUN_TEST(test_decode_ceiling_light_independent_of_nachlauf);
+  RUN_TEST(test_decode_nachlauf_alone_leaves_ceiling_light_off);
   RUN_TEST(test_decode_fan_stufe_1);
   RUN_TEST(test_decode_fan_stufe_2);
   RUN_TEST(test_decode_fan_stufe_3);

--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ The BFB 6bT remote works with Berbel hoods equipped with **berbel Connect 2.0**,
    cp src/config.example.h src/config.h
    ```
 
-2. **Edit `src/config.h`** with your WiFi and MQTT credentials. If your hood has no retractable cover (lift function), set `HOOD_HAS_COVER` to `false` to disable the Position, Hochfahren, Herunterfahren, and Cover State entities.
+2. **Edit `src/config.h`** with your WiFi and MQTT credentials, then match the two feature flags to your hood:
+
+   | Flag | Default | Set it when |
+   |------|---------|-------------|
+   | `HOOD_HAS_COVER` | `true` | Your hood has no retractable cover (lift function): set `false` to drop the Position, Hochfahren, Herunterfahren and Cover State entities. |
+   | `HOOD_HAS_CEILING_LIGHT` | `false` | Your hood has a ceiling connection with effect lighting (a third lamp): set `true` to add the Deckenlicht entity. |
 
 3. **Build and flash:**
    ```bash
@@ -75,6 +80,7 @@ All entities are created automatically via MQTT auto-discovery.
 |--------|------|-------------|
 | Oberlicht | Light | Upper/effect light toggle |
 | Unterlicht | Light | Cooktop light toggle |
+| Deckenlicht | Light | Ceiling connection light toggle *(`HOOD_HAS_CEILING_LIGHT` only)* |
 | Lufter | Select | Fan speed: Aus, Stufe 1-3, Power |
 | Ausschalten | Button | Power off (starts afterrun timer) |
 | Nachlauf | Switch | Toggle afterrun timer |
@@ -87,23 +93,26 @@ All entities are created automatically via MQTT auto-discovery.
 
 ## Button Codes
 
-Complete mapping of all 13 buttons on the BFB 6bT remote control, with official function names from the Berbel manual.
+Complete mapping of all 13 buttons on the BFB 6bT remote control. The codes themselves are reverse engineered,
+the function names come from the Berbel manual (document 6005229_0). Codes marked as verified were confirmed by
+driving them on a real hood; the rest are assigned by elimination and may still be swapped. Whether a hood
+performs a function at all depends on its equipment.
 
-| Code | Remote Label | Official Function (Berbel Manual) |
-|------|-------------|-----------------------------------|
-| 0x01 | Power | EIN/AUS |
-| 0x02 | Fan 1 | Leistungsstufe 1 |
-| 0x03 | Fan 2 | Leistungsstufe 2 |
-| 0x04 | Fan 3 | Leistungsstufe 3 |
-| 0x05 | Fan P | Leistungsstufe POWER |
-| 0x06 | Cooktop Light | Kochfeld-Beleuchtung |
-| 0x07 | Sync | Synchronisation |
-| 0x08 | Recirculation | Umluftbetrieb / Kontrollanzeige Filter |
-| 0x09 | Raise | Liftfunktion "Heben" |
-| 0x0A | Effect Light | Effektbeleuchtung |
-| 0x0B | Multi | Multifunktionstaste |
-| 0x0C | Afterrun | Nachlauffunktion |
-| 0x0D | Lower | Liftfunktion "Senken" |
+| Code | Function | Berbel Manual Term | Verified |
+|------|----------|--------------------|----------|
+| 0x01 | Power | EIN/AUS | yes |
+| 0x02 | Fan 1 | Leistungsstufe 1 | yes |
+| 0x03 | Fan 2 | Leistungsstufe 2 | yes |
+| 0x04 | Fan 3 | Leistungsstufe 3 | yes |
+| 0x05 | Fan P | Leistungsstufe POWER | yes |
+| 0x06 | Effect Light (Oberlicht) | Effektbeleuchtung | yes |
+| 0x07 | Sync | Synchronisation | no, by elimination |
+| 0x08 | Recirculation | Umluftbetrieb / Kontrollanzeige Filter | no, by elimination |
+| 0x09 | Raise | Liftfunktion "Heben" | yes |
+| 0x0A | Cooktop Light (Unterlicht) | Kochfeld-Beleuchtung | yes |
+| 0x0B | Ceiling Light | Multifunktionstaste (e.g. Deckenanschluss mit Effektbeleuchtung) | yes |
+| 0x0C | Afterrun | Nachlauffunktion | yes |
+| 0x0D | Lower | Liftfunktion "Senken" | yes |
 
 Protocol: 2-byte notifications on characteristic `f004f002-...-berbel`. Press: `[code, 0x00]`, Release: `[0x00, 0x00]`.
 
@@ -120,6 +129,7 @@ The hood sends 9-byte status packets on characteristic `f004f001-...-berbel`. Al
 | [2] | 0x10 | Oberlicht (upper light) |
 | [4] | 0x10 | Unterlicht (cooktop light) |
 | [4] | 0x01 | Cover moving up (retracting) *(`HOOD_HAS_COVER` only)* |
+| [5] | 0x01 | Deckenlicht (ceiling connection light) *(`HOOD_HAS_CEILING_LIGHT` only)* |
 | [5] | 0x90 | Nachlauf (afterrun timer active) |
 | [6] | 0x01 | Cover moving down (deploying) *(`HOOD_HAS_COVER` only)* |
 

--- a/REVERSE_ENGINEERING.md
+++ b/REVERSE_ENGINEERING.md
@@ -136,21 +136,27 @@ Commands are sent as 2-byte notifications on `f004f002`:
 
 ### Complete Button Mapping
 
-| Code | Remote Label | Official Function (Berbel Manual) |
-|------|-------------|-----------------------------------|
-| 0x01 | Power | EIN/AUS |
-| 0x02 | Fan 1 | Leistungsstufe 1 |
-| 0x03 | Fan 2 | Leistungsstufe 2 |
-| 0x04 | Fan 3 | Leistungsstufe 3 |
-| 0x05 | Fan P | Leistungsstufe POWER |
-| 0x06 | Cooktop Light | Kochfeld-Beleuchtung |
-| 0x07 | Sync | Synchronisation |
-| 0x08 | Recirculation | Umluftbetrieb / Kontrollanzeige Filter |
-| 0x09 | Raise | Liftfunktion "Heben" |
-| 0x0A | Effect Light | Effektbeleuchtung |
-| 0x0B | Multi | Multifunktionstaste |
-| 0x0C | Afterrun | Nachlauffunktion |
-| 0x0D | Lower | Liftfunktion "Senken" |
+Codes are reverse engineered by pressing each button and recording the notification. The function names come
+from the Berbel manual (document 6005229_0); the manual does not publish the codes, so the mapping between the
+two is only as good as the hood it was confirmed on. The manual's own function table lists Kochfeld-Beleuchtung
+before Effektbeleuchtung, but on the hoods tested so far the codes are the other way round, so do not assume
+the unverified rows follow the manual's order either.
+
+| Code | Function | Berbel Manual Term | Verified |
+|------|----------|--------------------|----------|
+| 0x01 | Power | EIN/AUS | yes |
+| 0x02 | Fan 1 | Leistungsstufe 1 | yes |
+| 0x03 | Fan 2 | Leistungsstufe 2 | yes |
+| 0x04 | Fan 3 | Leistungsstufe 3 | yes |
+| 0x05 | Fan P | Leistungsstufe POWER | yes |
+| 0x06 | Effect Light (Oberlicht) | Effektbeleuchtung | yes |
+| 0x07 | Sync | Synchronisation | no, by elimination |
+| 0x08 | Recirculation | Umluftbetrieb / Kontrollanzeige Filter | no, by elimination |
+| 0x09 | Raise | Liftfunktion "Heben" | yes |
+| 0x0A | Cooktop Light (Unterlicht) | Kochfeld-Beleuchtung | yes |
+| 0x0B | Ceiling Light | Multifunktionstaste (e.g. Deckenanschluss mit Effektbeleuchtung) | yes |
+| 0x0C | Afterrun | Nachlauffunktion | yes |
+| 0x0D | Lower | Liftfunktion "Senken" | yes |
 
 ## Hood Status Protocol
 
@@ -165,6 +171,7 @@ The hood writes 9-byte status packets to `f004f001`. All values are bitmask-base
 | [2] | 0x10 | Oberlicht (upper light) |
 | [4] | 0x10 | Unterlicht (cooktop light) |
 | [4] | 0x01 | Cover moving up (retracting) |
+| [5] | 0x01 | Deckenlicht (ceiling connection light) |
 | [5] | 0x90 | Nachlauf (afterrun timer active) |
 | [6] | 0x01 | Cover moving down (deploying) |
 

--- a/berbel_button_map.json
+++ b/berbel_button_map.json
@@ -12,19 +12,84 @@
     "release_format": "00 00"
   },
   "buttons": {
-    "0x01": { "code": 1, "hex": "01 00", "label": "power", "description": "Power ON/OFF" },
-    "0x02": { "code": 2, "hex": "02 00", "label": "fan_1", "description": "Fan Level 1" },
-    "0x03": { "code": 3, "hex": "03 00", "label": "fan_2", "description": "Fan Level 2" },
-    "0x04": { "code": 4, "hex": "04 00", "label": "fan_3", "description": "Fan Level 3" },
-    "0x05": { "code": 5, "hex": "05 00", "label": "fan_p", "description": "Fan Power Level (P)" },
-    "0x06": { "code": 6, "hex": "06 00", "label": "light_up", "description": "Light Up Toggle" },
-    "0x07": { "code": 7, "hex": "07 00", "label": "play", "description": "Play" },
-    "0x08": { "code": 8, "hex": "08 00", "label": "reload", "description": "Reload" },
-    "0x09": { "code": 9, "hex": "09 00", "label": "move_up", "description": "Move Up" },
-    "0x0a": { "code": 10, "hex": "0a 00", "label": "light_down", "description": "Light Down Toggle" },
-    "0x0b": { "code": 11, "hex": "0b 00", "label": "record", "description": "Record" },
-    "0x0c": { "code": 12, "hex": "0c 00", "label": "timer", "description": "Timer" },
-    "0x0d": { "code": 13, "hex": "0d 00", "label": "move_down", "description": "Move Down" }
+    "0x01": {
+      "code": 1,
+      "hex": "01 00",
+      "label": "power",
+      "description": "EIN/AUS"
+    },
+    "0x02": {
+      "code": 2,
+      "hex": "02 00",
+      "label": "fan_1",
+      "description": "Leistungsstufe 1"
+    },
+    "0x03": {
+      "code": 3,
+      "hex": "03 00",
+      "label": "fan_2",
+      "description": "Leistungsstufe 2"
+    },
+    "0x04": {
+      "code": 4,
+      "hex": "04 00",
+      "label": "fan_3",
+      "description": "Leistungsstufe 3"
+    },
+    "0x05": {
+      "code": 5,
+      "hex": "05 00",
+      "label": "fan_p",
+      "description": "Leistungsstufe POWER"
+    },
+    "0x06": {
+      "code": 6,
+      "hex": "06 00",
+      "label": "light_up",
+      "description": "Effektbeleuchtung (Oberlicht)"
+    },
+    "0x07": {
+      "code": 7,
+      "hex": "07 00",
+      "label": "sync",
+      "description": "Synchronisation"
+    },
+    "0x08": {
+      "code": 8,
+      "hex": "08 00",
+      "label": "recirc",
+      "description": "Umluftbetrieb / Kontrollanzeige Filter-Füllung"
+    },
+    "0x09": {
+      "code": 9,
+      "hex": "09 00",
+      "label": "move_up",
+      "description": "Liftfunktion \"Heben\""
+    },
+    "0x0a": {
+      "code": 10,
+      "hex": "0a 00",
+      "label": "light_down",
+      "description": "Kochfeld-Beleuchtung (Unterlicht)"
+    },
+    "0x0b": {
+      "code": 11,
+      "hex": "0b 00",
+      "label": "multi",
+      "description": "Multifunktionstaste (e.g. Deckenanschluss mit Effektbeleuchtung)"
+    },
+    "0x0c": {
+      "code": 12,
+      "hex": "0c 00",
+      "label": "timer",
+      "description": "Nachlauffunktion"
+    },
+    "0x0d": {
+      "code": 13,
+      "hex": "0d 00",
+      "label": "move_down",
+      "description": "Liftfunktion \"Senken\""
+    }
   },
   "buttons_by_label": {
     "power": 1,
@@ -33,14 +98,14 @@
     "fan_3": 4,
     "fan_p": 5,
     "light_up": 6,
-    "play": 7,
-    "reload": 8,
+    "sync": 7,
+    "recirc": 8,
     "move_up": 9,
     "light_down": 10,
-    "record": 11,
+    "multi": 11,
     "timer": 12,
     "move_down": 13
   },
   "capture_date": "2026-01-03",
-  "notes": "Complete button mapping for Berbel Skyline Frame remote control. 13 buttons, codes 0x01-0x0D."
+  "notes": "Complete button mapping for the Berbel BFB 6bT remote control, 13 buttons, codes 0x01-0x0D. The codes are reverse engineered; the function names come from the Berbel manual 6005229_0, which does not publish the codes. The light assignment was confirmed on real hoods and is the reverse of the manual's function-table order, so 0x07 and 0x08 (assigned by elimination) may still be swapped. Which functions a button performs depends on the hood's equipment."
 }


### PR DESCRIPTION
Implements #3.

## Third light

Hoods with a **ceiling connection with effect lighting** ("Deckenanschluss mit Effektbeleuchtung", a separate accessory) have a third lamp. The Berbel manual (document 6005229_0, section 3.2.8) describes it as driven by the multifunction button, and @buggyschlock measured exactly that: button `0x0B` toggles it cleanly, and its state is reported in status byte `[5]` bit 0, independent of the two known light bits.

New entity **Deckenlicht**, behind a new config flag:

```c
#define HOOD_HAS_CEILING_LIGHT false
```

The flag defaults to off, so nobody gets an entity that toggles nothing. It also defaults to off for a `config.h` from an older checkout, which does not define it at all. Turning it back off removes the entity from Home Assistant again, instead of leaving a dead toggle behind.

Like the other lights, the entity checks its state before sending, so a `turn_on` on an already lit lamp no longer switches it off. That was the workaround needed when driving `0x0B` through the debug topic.

## Corrected button codes

The side note in #3 was right: the two tables disagreed. It is the button code table that was wrong, not the entity table.

The codes are reverse engineered, the function names come from the manual, and the manual does not publish the codes. The mapping between the two was inferred from the order of the manual's function table, and for the two light buttons that inference is wrong. Confirmed on hardware:

| Code | Actually drives | Manual term |
|------|-----------------|-------------|
| `0x06` | Oberlicht | Effektbeleuchtung |
| `0x0A` | Unterlicht | Kochfeld-Beleuchtung |

Both doc tables now carry a `Verified` column, so it is visible that `0x07` and `0x08` are still only assigned by elimination and may be swapped as well.

Entity names are unchanged. `Oberlicht` and `Unterlicht` were already correct.

## Also in here

- The remaining symbol-named button defines now read like the rest: `BTN_PLAY` to `BTN_SYNC`, `BTN_RELOAD` to `BTN_RECIRC`, `BTN_RECORD` to `BTN_MULTI`. None of them had a caller.
- CI compiles all four combinations of the hood feature flags. Previously it only built `config.example.h`, so a typo inside a disabled `#if` block passed CI and broke the build only for whoever enabled that flag.

## Verification

- `pio test -e native`: 37 of 37 pass, 4 of them new (the ceiling bit, the captured all-three-lamps packet from #3, and that the bit does not collide with Nachlauf in the same byte).
- Firmware builds in all four flag combinations, plus `config.example.h` verbatim, plus a `config.h` that predates the flag.

Not verified on hardware: the maintainer's hood has no ceiling connection, its byte `[5]` reads `00` throughout the recorded history. The decode follows the measurements in #3 and is confirmed on that one hood only, which is noted at the decode site and in the test. @buggyschlock, a test against a real build would be welcome.
