### PR TITLE
Decode status frames by length, with a layout table per model

### DIFF
--- a/BerbelRemote/src/berbel_protocol.h
+++ b/BerbelRemote/src/berbel_protocol.h
@@ -1,5 +1,5 @@
 /**
- * Berbel BFB 6bT - pure protocol logic (no Arduino/NimBLE dependencies).
+ * Berbel hood - pure protocol logic (no Arduino/NimBLE dependencies).
  *
  * Everything here is a side-effect-free function of its inputs so it can be
  * unit-tested on the host with PlatformIO's `native` environment. The decode
@@ -14,7 +14,7 @@
 
 namespace berbel {
 
-// Decoded view of a 9-byte hood status notification.
+// Decoded view of a hood status notification.
 struct DecodedStatus {
   bool lightUp = false;       // Oberlicht
   bool lightDown = false;     // Unterlicht
@@ -25,36 +25,112 @@ struct DecodedStatus {
   bool movingDown = false;    // cover deploying
 };
 
+// Longest status frame known. The BFB 6bT sends 9 bytes, the Skyline Edge Play
+// 13. Frames are truncated to this length, anything beyond stays undecoded.
+static const size_t STATUS_MAX_LEN = 13;
+
+// One flag in the status frame: which byte carries it, and which bits to test.
+struct StatusBit {
+  uint8_t index;
+  uint8_t mask;
+};
+
+// Where each flag sits in the frame. Hood models disagree on this and the frame
+// length is the only thing that tells them apart, so every field is looked up in
+// a layout rather than read from a fixed offset. A model that moves another flag
+// is one more table below, not another branch in the decoder.
+struct StatusLayout {
+  StatusBit fanStep1;
+  StatusBit fanStep2;
+  StatusBit fanStep3;
+  StatusBit fanPower;
+  StatusBit lightUp;
+  StatusBit lightDown;
+  StatusBit lightCeiling;
+  StatusBit nachlauf;
+  StatusBit movingUp;
+  StatusBit movingDown;
+};
+
+// 9-byte frame (BFB 6bT). Every field measured.
+static const StatusLayout LAYOUT_SHORT = {
+  /* fanStep1     */ {0, 0x10},
+  /* fanStep2     */ {1, 0x01},
+  /* fanStep3     */ {1, 0x10},
+  /* fanPower     */ {2, 0x09},
+  /* lightUp      */ {2, 0x10},
+  /* lightDown    */ {4, 0x10},
+  /* lightCeiling */ {5, 0x01},
+  /* nachlauf     */ {5, 0x90},
+  /* movingUp     */ {4, 0x01},
+  /* movingDown   */ {6, 0x01},
+};
+
+// 13-byte frame (Skyline Edge Play). The three fan steps and Unterlicht sit where
+// the short frame puts them, and the Deckenlicht has moved from byte 5 to byte 9;
+// those five are measured (issue #3). The remaining fields are carried over from
+// the short layout and are NOT confirmed on this frame.
+static const StatusLayout LAYOUT_LONG = {
+  /* fanStep1     */ {0, 0x10},
+  /* fanStep2     */ {1, 0x01},
+  /* fanStep3     */ {1, 0x10},
+  /* fanPower     */ {2, 0x09},
+  /* lightUp      */ {2, 0x10},
+  /* lightDown    */ {4, 0x10},
+  /* lightCeiling */ {9, 0x01},
+  /* nachlauf     */ {5, 0x90},
+  /* movingUp     */ {4, 0x01},
+  /* movingDown   */ {6, 0x01},
+};
+
+// Pick the layout for a frame of `len` bytes. Only a length we have measured gets
+// its own layout; everything else falls back to the short one, whose indices stay
+// within the nine bytes every hood agrees on.
+inline StatusLayout statusLayout(size_t len) {
+  return len == STATUS_MAX_LEN ? LAYOUT_LONG : LAYOUT_SHORT;
+}
+
+inline bool statusBitSet(const uint8_t* raw, StatusBit bit) {
+  return (raw[bit.index] & bit.mask) != 0;
+}
+
 // Hood sends an all-0x11 sync packet on connect that carries no real state.
+// Only the first nine bytes are checked: that is the whole packet on a 9-byte
+// hood, and what a longer frame carries after them has never been measured.
+// Requiring 0x11 there too would risk taking a sync packet for real state and
+// publishing it retained over the last known good one.
 inline bool isSyncPacket(const uint8_t raw[9]) {
-  for (int i = 0; i < 9; i++) {
+  for (size_t i = 0; i < 9; i++) {
     if (raw[i] != 0x11) return false;
   }
   return true;
 }
 
-// Decode the 9-byte bitmask status into discrete fields.
-inline DecodedStatus decodeHoodStatus(const uint8_t raw[9]) {
+// Decode the bitmask status into discrete fields, using the layout that matches
+// the frame length.
+inline DecodedStatus decodeHoodStatus(const uint8_t* raw, size_t len) {
+  const StatusLayout l = statusLayout(len);
   DecodedStatus s;
 
-  // Lights (bits don't overlap with fan)
-  s.lightUp = (raw[2] & 0x10) != 0;       // Oberlicht: byte 2, bit 4
-  s.lightDown = (raw[4] & 0x10) != 0;     // Unterlicht: byte 4, bit 4
-  // Deckenlicht: byte 5, bit 0. Shares the byte with Nachlauf (0x90) but no bits
-  // overlap. Confirmed on a single hood (issue #3), unverified elsewhere.
-  s.lightCeiling = (raw[5] & 0x01) != 0;
+  s.lightUp = statusBitSet(raw, l.lightUp);
+  s.lightDown = statusBitSet(raw, l.lightDown);
+  s.lightCeiling = statusBitSet(raw, l.lightCeiling);
 
   // Fan speed (only one active at a time)
-  if (raw[2] & 0x09)      s.fanSpeed = 4;  // Power:   0000 1001
-  else if (raw[1] & 0x10) s.fanSpeed = 3;  // Stufe 3: 0001 0000
-  else if (raw[1] & 0x01) s.fanSpeed = 2;  // Stufe 2: 0000 0001
-  else if (raw[0] & 0x10) s.fanSpeed = 1;  // Stufe 1: 0001 0000
-  else                    s.fanSpeed = 0;  // Aus
+  if (statusBitSet(raw, l.fanPower))       s.fanSpeed = 4;
+  else if (statusBitSet(raw, l.fanStep3))  s.fanSpeed = 3;
+  else if (statusBitSet(raw, l.fanStep2))  s.fanSpeed = 2;
+  else if (statusBitSet(raw, l.fanStep1))  s.fanSpeed = 1;
+  else                                     s.fanSpeed = 0;
 
-  s.nachlauf = (raw[5] & 0x90) != 0;       // parallel to fan speed
-  s.movingUp = (raw[4] & 0x01) != 0;
-  s.movingDown = (raw[6] & 0x01) != 0;
+  s.nachlauf = statusBitSet(raw, l.nachlauf);  // parallel to fan speed
+  s.movingUp = statusBitSet(raw, l.movingUp);
+  s.movingDown = statusBitSet(raw, l.movingDown);
   return s;
+}
+
+inline DecodedStatus decodeHoodStatus(const uint8_t raw[9]) {
+  return decodeHoodStatus(raw, 9);
 }
 
 // Cover state machine result. Strings match the HA entity values.
@@ -111,11 +187,21 @@ inline bool jsonGetValue(const char* json, const char* key, char* out, size_t ou
   return true;
 }
 
-// Parse the space-separated 9-byte hex string used for `status_raw`
-// (e.g. "00 00 00 00 10 00 00 00 00") back into raw bytes. `out` is only
-// written on success. Returns false unless the string holds exactly 9
-// two-digit hex bytes separated by single spaces.
-inline bool parseStatusRaw(const char* s, uint8_t out[9]) {
+// Render `len` bytes as the space-separated hex string used for `status_raw`
+// (e.g. "00 00 00 00 10 00 00 00 00"). Needs `len * 3` bytes of room in `out`.
+inline void formatStatusRaw(const uint8_t* raw, size_t len, char* out, size_t outLen) {
+  if (outLen == 0) return;
+  size_t pos = 0;
+  for (size_t i = 0; i < len && pos + 3 < outLen; i++) {
+    pos += snprintf(out + pos, outLen - pos, i == 0 ? "%02X" : " %02X", raw[i]);
+  }
+  out[pos] = '\0';
+}
+
+// Parse the space-separated hex string used for `status_raw` back into bytes.
+// Returns the number of bytes parsed, 0 if the string is malformed, holds fewer
+// than 9 bytes or more than fit. `out` is only written on success.
+inline size_t parseStatusRaw(const char* s, uint8_t* out, size_t outLen) {
   auto hexVal = [](char c) -> int {
     if (c >= '0' && c <= '9') return c - '0';
     if (c >= 'A' && c <= 'F') return c - 'A' + 10;
@@ -123,21 +209,23 @@ inline bool parseStatusRaw(const char* s, uint8_t out[9]) {
     return -1;
   };
 
-  uint8_t parsed[9];
+  uint8_t parsed[STATUS_MAX_LEN];
+  size_t count = 0;
   const char* p = s;
-  for (int i = 0; i < 9; i++) {
-    if (i > 0 && *p++ != ' ') return false;
+  while (*p != '\0') {
+    if (count > 0 && *p++ != ' ') return 0;
+    if (count >= STATUS_MAX_LEN || count >= outLen) return 0;
     int hi = hexVal(p[0]);
-    if (hi < 0) return false;
+    if (hi < 0) return 0;
     int lo = hexVal(p[1]);
-    if (lo < 0) return false;
-    parsed[i] = (uint8_t)((hi << 4) | lo);
+    if (lo < 0) return 0;
+    parsed[count++] = (uint8_t)((hi << 4) | lo);
     p += 2;
   }
-  if (*p != '\0') return false;
+  if (count < 9) return 0;
 
-  memcpy(out, parsed, 9);
-  return true;
+  memcpy(out, parsed, count);
+  return count;
 }
 
 }  // namespace berbel

--- a/BerbelRemote/src/main.cpp
+++ b/BerbelRemote/src/main.cpp
@@ -13,7 +13,7 @@
  * - Hood status:    9-byte writes from hood on f004f001
  * - Sync packet:    all 0x11 (ignored, sent on connect)
  *
- * Hood Status Bytes (9 bytes, bitmask-based):
+ * Hood Status Bytes (first 9 bytes of the frame, bitmask-based):
  *   Byte[0] & 0x10  = Fan Stufe 1
  *   Byte[1] & 0x01  = Fan Stufe 2
  *   Byte[1] & 0x10  = Fan Stufe 3
@@ -454,7 +454,10 @@ class WriteCallbacks : public NimBLECharacteristicCallbacks {
     }
     Log.println();
 
-    if (value.length() == 9) {
+    // Some models send a longer frame (the Skyline Edge Play sends 13 bytes)
+    // whose leading bytes carry the same fields. Anything past the ninth is not
+    // decoded yet.
+    if (value.length() >= 9) {
       memcpy(pendingStatus, (const uint8_t*)value.data(), 9);
       newStatusReceived = true;
     }

--- a/BerbelRemote/src/main.cpp
+++ b/BerbelRemote/src/main.cpp
@@ -10,10 +10,10 @@
  * BLE Protocol (reverse engineered):
  * - Button press:   [code, 0x00] as 2-byte notification on f004f002
  * - Button release: [0x00, 0x00] as 2-byte notification on f004f002
- * - Hood status:    9-byte writes from hood on f004f001
+ * - Hood status:    status writes from hood on f004f001
  * - Sync packet:    all 0x11 (ignored, sent on connect)
  *
- * Hood Status Bytes (first 9 bytes of the frame, bitmask-based):
+ * Hood Status Bytes (bitmask-based):
  *   Byte[0] & 0x10  = Fan Stufe 1
  *   Byte[1] & 0x01  = Fan Stufe 2
  *   Byte[1] & 0x10  = Fan Stufe 3
@@ -24,6 +24,11 @@
  *   Byte[5] & 0x01  = Deckenlicht (ceiling connection light)
  *   Byte[5] & 0x90  = Nachlauf (afterrun timer active)
  *   Byte[6] & 0x01  = Cover moving down (deploying)
+ *
+ * Frame length varies by model and not every flag sits in the same place: the
+ * BFB 6bT sends 9 bytes, the Skyline Edge Play 13 with the Deckenlicht on
+ * byte[9] instead of byte[5]. The positions live in the layout tables in
+ * berbel_protocol.h, which are picked by frame length.
  *
  * HA Entities (via MQTT Auto-Discovery):
  *   - Oberlicht       (light)          Toggle upper light
@@ -37,7 +42,7 @@
  *   - Herunterfahren  (button)         Move down unconditionally (only with HOOD_HAS_COVER)
  *   - BLE Verbindung  (binary_sensor)  BLE connection status
  *   - Cover State     (sensor)         Diagnostic: up/moving up/moving down/down (only with HOOD_HAS_COVER)
- *   - Status Raw      (sensor)         Raw 9-byte hex for debugging
+ *   - Status Raw      (sensor)         Raw status frame as hex, for debugging
  *
  * Critical requirements:
  * 1. MAC must use Texas Instruments OUI (88:01:F9 or 30:AF:7E)
@@ -136,7 +141,8 @@ struct HoodState {
   const char* coverState = "up";  // up, moving up, moving down, down
 #endif
   bool bleConnected = false;
-  uint8_t raw[9] = {0};
+  uint8_t raw[berbel::STATUS_MAX_LEN] = {0};
+  size_t rawLen = 9;
 };
 
 // ============================================================================
@@ -177,7 +183,8 @@ bool hoodStateValid = false;  // true after first real status from hood (not syn
 
 // Status update from BLE callback (processed in loop)
 volatile bool newStatusReceived = false;
-uint8_t pendingStatus[9];
+uint8_t pendingStatus[berbel::STATUS_MAX_LEN];
+volatile size_t pendingStatusLen = 0;
 
 // Command queue (prevents commands from overlapping when scenes send multiple at once)
 struct CmdEntry {
@@ -454,11 +461,14 @@ class WriteCallbacks : public NimBLECharacteristicCallbacks {
     }
     Log.println();
 
-    // Some models send a longer frame (the Skyline Edge Play sends 13 bytes)
-    // whose leading bytes carry the same fields. Anything past the ninth is not
-    // decoded yet.
+    // Models differ in frame length and in where they put some of the flags, so
+    // the length is kept and the decoder picks its layout from it. A frame longer
+    // than any layout covers is taken as the nine bytes every hood agrees on,
+    // rather than guessed at with the layout of a different model.
     if (value.length() >= 9) {
-      memcpy(pendingStatus, (const uint8_t*)value.data(), 9);
+      size_t len = value.length() <= berbel::STATUS_MAX_LEN ? value.length() : 9;
+      memcpy(pendingStatus, (const uint8_t*)value.data(), len);
+      pendingStatusLen = len;
       newStatusReceived = true;
     }
   }
@@ -533,6 +543,9 @@ void publishState() {
     return;
   }
 
+  char rawHex[berbel::STATUS_MAX_LEN * 3];
+  berbel::formatStatusRaw(hood.raw, hood.rawLen, rawHex, sizeof(rawHex));
+
   char json[384];
   snprintf(json, sizeof(json),
     "{"
@@ -548,7 +561,7 @@ void publishState() {
     "\"cover_state\":\"%s\","
 #endif
     "\"ble\":\"%s\","
-    "\"status_raw\":\"%02X %02X %02X %02X %02X %02X %02X %02X %02X\""
+    "\"status_raw\":\"%s\""
     "}",
     hood.lightUp ? "ON" : "OFF",
     hood.lightDown ? "ON" : "OFF",
@@ -562,8 +575,7 @@ void publishState() {
     hood.coverState,
 #endif
     hood.bleConnected ? "ON" : "OFF",
-    hood.raw[0], hood.raw[1], hood.raw[2], hood.raw[3], hood.raw[4],
-    hood.raw[5], hood.raw[6], hood.raw[7], hood.raw[8]);
+    rawHex);
 
   mqtt.publish(MQTT_STATE, json, true);
 }
@@ -775,7 +787,8 @@ void publishDiscovery() {
 // Restore hood state from retained MQTT message (simple JSON parser)
 // ============================================================================
 void restoreStateFromMqtt(const char* json) {
-  char val[32];
+  // Wide enough for the longest status_raw string (13 bytes as "XX " pairs).
+  char val[berbel::STATUS_MAX_LEN * 3];
 
   if (berbel::jsonGetValue(json, "light_up", val, sizeof(val)))
     hood.lightUp = (strcmp(val, "ON") == 0);
@@ -789,8 +802,10 @@ void restoreStateFromMqtt(const char* json) {
     hood.nachlauf = (strcmp(val, "ON") == 0);
   if (berbel::jsonGetValue(json, "fan_preset", val, sizeof(val)))
     hood.fanSpeed = berbel::fanPresetToSpeed(val);
-  if (berbel::jsonGetValue(json, "status_raw", val, sizeof(val)))
-    berbel::parseStatusRaw(val, hood.raw);
+  if (berbel::jsonGetValue(json, "status_raw", val, sizeof(val))) {
+    size_t len = berbel::parseStatusRaw(val, hood.raw, sizeof(hood.raw));
+    if (len > 0) hood.rawLen = len;
+  }
 #if HOOD_HAS_COVER
   if (berbel::jsonGetValue(json, "position", val, sizeof(val)))
     hood.position = (strcmp(val, "Unten") == 0) ? "Unten" : "Oben";
@@ -1272,9 +1287,10 @@ void loop() {
       Log.println("[HOOD] Sync packet ignored");
     } else {
       hoodStateValid = true;
-      memcpy(hood.raw, pendingStatus, 9);
+      hood.rawLen = pendingStatusLen;
+      memcpy(hood.raw, pendingStatus, hood.rawLen);
 
-      berbel::DecodedStatus status = berbel::decodeHoodStatus(hood.raw);
+      berbel::DecodedStatus status = berbel::decodeHoodStatus(hood.raw, hood.rawLen);
       hood.lightUp   = status.lightUp;
       hood.lightDown = status.lightDown;
 #if HOOD_HAS_CEILING_LIGHT

--- a/BerbelRemote/test/test_protocol/test_protocol.cpp
+++ b/BerbelRemote/test/test_protocol/test_protocol.cpp
@@ -254,51 +254,149 @@ void test_json_get_value_buffer_too_small(void) {
 }
 
 // ----------------------------------------------------------------------------
+// decodeHoodStatus - 13-byte frame (Skyline Edge Play, measured in issue #3)
+// ----------------------------------------------------------------------------
+void test_long_frame_all_off(void) {
+  uint8_t raw[STATUS_MAX_LEN] = {0};
+  DecodedStatus s = decodeHoodStatus(raw, STATUS_MAX_LEN);
+  TEST_ASSERT_FALSE(s.lightDown);
+  TEST_ASSERT_FALSE(s.lightCeiling);
+  TEST_ASSERT_EQUAL_UINT8(0, s.fanSpeed);
+}
+
+void test_long_frame_light_down(void) {
+  uint8_t raw[STATUS_MAX_LEN] = {0};
+  raw[4] = 0x10;
+  DecodedStatus s = decodeHoodStatus(raw, STATUS_MAX_LEN);
+  TEST_ASSERT_TRUE(s.lightDown);
+  TEST_ASSERT_FALSE(s.lightCeiling);
+}
+
+// The one flag that moved: byte 9 on the long frame, byte 5 on the short one.
+void test_long_frame_light_ceiling(void) {
+  uint8_t raw[STATUS_MAX_LEN] = {0};
+  raw[9] = 0x01;
+  DecodedStatus s = decodeHoodStatus(raw, STATUS_MAX_LEN);
+  TEST_ASSERT_TRUE(s.lightCeiling);
+  TEST_ASSERT_FALSE(s.lightDown);
+}
+
+void test_long_frame_ignores_short_frame_ceiling_bit(void) {
+  uint8_t raw[STATUS_MAX_LEN] = {0};
+  raw[5] = 0x01;
+  TEST_ASSERT_FALSE(decodeHoodStatus(raw, STATUS_MAX_LEN).lightCeiling);
+}
+
+void test_long_frame_both_lights(void) {
+  uint8_t raw[STATUS_MAX_LEN] = {0};
+  raw[4] = 0x10;
+  raw[9] = 0x01;
+  DecodedStatus s = decodeHoodStatus(raw, STATUS_MAX_LEN);
+  TEST_ASSERT_TRUE(s.lightDown);
+  TEST_ASSERT_TRUE(s.lightCeiling);
+}
+
+void test_long_frame_fan_steps(void) {
+  uint8_t raw[STATUS_MAX_LEN] = {0};
+  raw[0] = 0x10;
+  TEST_ASSERT_EQUAL_UINT8(1, decodeHoodStatus(raw, STATUS_MAX_LEN).fanSpeed);
+
+  memset(raw, 0, sizeof(raw));
+  raw[1] = 0x01;
+  TEST_ASSERT_EQUAL_UINT8(2, decodeHoodStatus(raw, STATUS_MAX_LEN).fanSpeed);
+
+  memset(raw, 0, sizeof(raw));
+  raw[1] = 0x10;
+  TEST_ASSERT_EQUAL_UINT8(3, decodeHoodStatus(raw, STATUS_MAX_LEN).fanSpeed);
+}
+
+// A hood whose frame length we have never seen falls back to the short layout,
+// both below and above the lengths we do know.
+void test_unknown_frame_length_uses_short_layout(void) {
+  uint8_t raw[STATUS_MAX_LEN] = {0};
+  raw[5] = 0x01;
+  TEST_ASSERT_TRUE(decodeHoodStatus(raw, 11).lightCeiling);
+  TEST_ASSERT_TRUE(decodeHoodStatus(raw, 17).lightCeiling);
+  raw[5] = 0x00;
+  raw[9] = 0x01;
+  TEST_ASSERT_FALSE(decodeHoodStatus(raw, 17).lightCeiling);
+}
+
+// The sync packet is only ever recognised by its first nine bytes, so a longer
+// frame is still a sync packet whatever it carries after them.
+void test_sync_packet_ignores_bytes_past_the_ninth(void) {
+  uint8_t raw[STATUS_MAX_LEN];
+  memset(raw, 0x11, sizeof(raw));
+  TEST_ASSERT_TRUE(isSyncPacket(raw));
+  raw[12] = 0x00;
+  TEST_ASSERT_TRUE(isSyncPacket(raw));
+  raw[8] = 0x00;
+  TEST_ASSERT_FALSE(isSyncPacket(raw));
+}
+
+// ----------------------------------------------------------------------------
 // parseStatusRaw
 // ----------------------------------------------------------------------------
 void test_parse_status_raw_round_trip(void) {
   uint8_t original[9] = {0x00, 0x01, 0x10, 0x09, 0x10, 0x90, 0x01, 0xAB, 0xFF};
-  char text[32];
-  snprintf(text, sizeof(text), "%02X %02X %02X %02X %02X %02X %02X %02X %02X",
-           original[0], original[1], original[2], original[3], original[4],
-           original[5], original[6], original[7], original[8]);
+  char text[STATUS_MAX_LEN * 3];
+  formatStatusRaw(original, 9, text, sizeof(text));
 
-  uint8_t parsed[9] = {0};
-  TEST_ASSERT_TRUE(parseStatusRaw(text, parsed));
+  uint8_t parsed[STATUS_MAX_LEN] = {0};
+  TEST_ASSERT_EQUAL_size_t(9, parseStatusRaw(text, parsed, sizeof(parsed)));
   TEST_ASSERT_EQUAL_UINT8_ARRAY(original, parsed, 9);
 }
 
+void test_parse_status_raw_round_trip_long_frame(void) {
+  uint8_t original[STATUS_MAX_LEN] = {0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00,
+                                      0x00, 0x00, 0x01, 0x00, 0x00, 0x00};
+  char text[STATUS_MAX_LEN * 3];
+  formatStatusRaw(original, STATUS_MAX_LEN, text, sizeof(text));
+  TEST_ASSERT_EQUAL_STRING("00 00 00 00 10 00 00 00 00 01 00 00 00", text);
+
+  uint8_t parsed[STATUS_MAX_LEN] = {0};
+  TEST_ASSERT_EQUAL_size_t(STATUS_MAX_LEN, parseStatusRaw(text, parsed, sizeof(parsed)));
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(original, parsed, STATUS_MAX_LEN);
+}
+
 void test_parse_status_raw_lowercase(void) {
-  uint8_t parsed[9] = {0};
-  TEST_ASSERT_TRUE(parseStatusRaw("ab cd ef 00 11 22 33 44 55", parsed));
+  uint8_t parsed[STATUS_MAX_LEN] = {0};
+  TEST_ASSERT_TRUE(parseStatusRaw("ab cd ef 00 11 22 33 44 55", parsed, sizeof(parsed)));
   TEST_ASSERT_EQUAL_UINT8(0xAB, parsed[0]);
   TEST_ASSERT_EQUAL_UINT8(0xEF, parsed[2]);
 }
 
 void test_parse_status_raw_too_few_bytes(void) {
-  uint8_t parsed[9] = {0};
-  TEST_ASSERT_FALSE(parseStatusRaw("00 00 00 00", parsed));
+  uint8_t parsed[STATUS_MAX_LEN] = {0};
+  TEST_ASSERT_FALSE(parseStatusRaw("00 00 00 00", parsed, sizeof(parsed)));
 }
 
-void test_parse_status_raw_trailing_garbage(void) {
+void test_parse_status_raw_too_many_bytes(void) {
+  uint8_t parsed[STATUS_MAX_LEN] = {0};
+  TEST_ASSERT_FALSE(parseStatusRaw(
+    "00 00 00 00 00 00 00 00 00 00 00 00 00 00", parsed, sizeof(parsed)));
+}
+
+void test_parse_status_raw_rejects_frame_longer_than_buffer(void) {
   uint8_t parsed[9] = {0};
-  TEST_ASSERT_FALSE(parseStatusRaw("00 00 00 00 00 00 00 00 00 00", parsed));
+  TEST_ASSERT_FALSE(parseStatusRaw(
+    "00 00 00 00 10 00 00 00 00 01 00 00 00", parsed, sizeof(parsed)));
 }
 
 void test_parse_status_raw_non_hex(void) {
-  uint8_t parsed[9] = {0};
-  TEST_ASSERT_FALSE(parseStatusRaw("00 00 ZZ 00 00 00 00 00 00", parsed));
+  uint8_t parsed[STATUS_MAX_LEN] = {0};
+  TEST_ASSERT_FALSE(parseStatusRaw("00 00 ZZ 00 00 00 00 00 00", parsed, sizeof(parsed)));
 }
 
 void test_parse_status_raw_leaves_out_untouched_on_failure(void) {
   uint8_t parsed[9] = {0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE};
-  TEST_ASSERT_FALSE(parseStatusRaw("11 22 33 44 55 66 77 88 ZZ", parsed));
+  TEST_ASSERT_FALSE(parseStatusRaw("11 22 33 44 55 66 77 88 ZZ", parsed, sizeof(parsed)));
   for (int i = 0; i < 9; i++) TEST_ASSERT_EQUAL_UINT8(0xEE, parsed[i]);
 }
 
 void test_parse_status_raw_empty_string(void) {
-  uint8_t parsed[9] = {0};
-  TEST_ASSERT_FALSE(parseStatusRaw("", parsed));
+  uint8_t parsed[STATUS_MAX_LEN] = {0};
+  TEST_ASSERT_FALSE(parseStatusRaw("", parsed, sizeof(parsed)));
 }
 
 // ----------------------------------------------------------------------------
@@ -342,10 +440,21 @@ int main(int, char**) {
   RUN_TEST(test_json_get_value_missing_key);
   RUN_TEST(test_json_get_value_buffer_too_small);
 
+  RUN_TEST(test_long_frame_all_off);
+  RUN_TEST(test_long_frame_light_down);
+  RUN_TEST(test_long_frame_light_ceiling);
+  RUN_TEST(test_long_frame_ignores_short_frame_ceiling_bit);
+  RUN_TEST(test_long_frame_both_lights);
+  RUN_TEST(test_long_frame_fan_steps);
+  RUN_TEST(test_unknown_frame_length_uses_short_layout);
+  RUN_TEST(test_sync_packet_ignores_bytes_past_the_ninth);
+
   RUN_TEST(test_parse_status_raw_round_trip);
+  RUN_TEST(test_parse_status_raw_round_trip_long_frame);
   RUN_TEST(test_parse_status_raw_lowercase);
   RUN_TEST(test_parse_status_raw_too_few_bytes);
-  RUN_TEST(test_parse_status_raw_trailing_garbage);
+  RUN_TEST(test_parse_status_raw_too_many_bytes);
+  RUN_TEST(test_parse_status_raw_rejects_frame_longer_than_buffer);
   RUN_TEST(test_parse_status_raw_non_hex);
   RUN_TEST(test_parse_status_raw_leaves_out_untouched_on_failure);
   RUN_TEST(test_parse_status_raw_empty_string);

--- a/REVERSE_ENGINEERING.md
+++ b/REVERSE_ENGINEERING.md
@@ -119,7 +119,7 @@ This is the proprietary service used for all communication between remote and ho
 
 | Handle | UUID | Properties | Direction | Description |
 |--------|------|------------|-----------|-------------|
-| 0x0032 | f004f001-...-berbel | read, write-without-response | Hood -> Remote | **Hood status** (9-byte state packets) |
+| 0x0032 | f004f001-...-berbel | read, write-without-response | Hood -> Remote | **Hood status** (9 or 13-byte state packets) |
 | 0x0034 | f004f002-...-berbel | read, notify | Remote -> Hood | **Button commands** (2-byte notifications) |
 
 UUID breakdown:
@@ -160,7 +160,11 @@ the unverified rows follow the manual's order either.
 
 ## Hood Status Protocol
 
-The hood writes 9-byte status packets to `f004f001`. All values are bitmask-based.
+The hood writes bitmask-based status packets to `f004f001`. **The frame length
+differs by model**, and so does the position of at least one flag, so the
+firmware picks a layout table by frame length (`berbel_protocol.h`).
+
+### 9-byte frame (BFB 6bT)
 
 | Byte | Mask | Meaning |
 |------|------|---------|
@@ -174,6 +178,32 @@ The hood writes 9-byte status packets to `f004f001`. All values are bitmask-base
 | [5] | 0x01 | Deckenlicht (ceiling connection light) |
 | [5] | 0x90 | Nachlauf (afterrun timer active) |
 | [6] | 0x01 | Cover moving down (deploying) |
+
+### 13-byte frame (Skyline Edge Play)
+
+Measured in [issue #3](https://github.com/tfohlmeister/berbel-remote/issues/3).
+The fan steps and the Unterlicht keep their positions; the Deckenlicht moves
+from byte [5] to byte [9].
+
+| Byte | Mask | Meaning | Measured |
+|------|------|---------|----------|
+| [0] | 0x10 | Fan Stufe 1 | yes |
+| [1] | 0x01 | Fan Stufe 2 | yes |
+| [1] | 0x10 | Fan Stufe 3 | yes |
+| [2] | 0x09 | Fan Power | no, carried over |
+| [2] | 0x10 | Oberlicht (upper light) | no, carried over |
+| [4] | 0x10 | Unterlicht (cooktop light) | yes |
+| [4] | 0x01 | Cover moving up (retracting) | no, carried over |
+| [9] | 0x01 | Deckenlicht (ceiling connection light) | yes |
+| [5] | 0x90 | Nachlauf (afterrun timer active) | no, carried over |
+| [6] | 0x01 | Cover moving down (deploying) | no, carried over |
+
+**Open question:** why the two layouts exist, and how the original remote tells
+them apart. Its buttons light up in sync with the hood, so it decodes the same
+frames and must be making the same distinction, whether by frame length, by a
+model identifier exchanged during pairing, or by shipping firmware per model.
+Anything measured on a third model is welcome, particularly the flags marked
+"carried over" above, which are assumed rather than confirmed.
 
 On connect, the hood sends a sync packet (all bytes `0x11`) which should be ignored.
 


### PR DESCRIPTION
Fixes status decoding on hoods whose status frame differs from the nine bytes this firmware was written against. Reported in #3 by @jens-42 for the Skyline Edge Play, which sends 13 bytes and puts one flag in a different place.

## What was wrong

```cpp
if (value.length() == 9) {
  memcpy(pendingStatus, (const uint8_t*)value.data(), 9);
  newStatusReceived = true;
}
```

A 13 byte frame fails that check and is dropped. The `[HOOD] Status (13 bytes): …` line is printed before it, which hides the fact that nothing happens afterwards: `hoodStateValid` is never set, `hood.raw` is never filled, and every entity keeps the state it booted with.

That is not only a display problem. The toggle guard compares against the decoded state, so on such a hood it works off all zeroes forever:

```
[MQTT] berbel/hood/light_down/set = ON
[BTN] Sending: Light Down (0x0A)
[HOOD] Status (13 bytes): 00 00 00 00 10 00 00 00 00 00 00 00 00
[MQTT] berbel/hood/light_down/set = OFF
[MQTT] Unterlicht already OFF, skipping        <- it is on
[MQTT] berbel/hood/light_down/set = ON
[BTN] Sending: Light Down (0x0A)
[HOOD] Status (13 bytes): 00 00 00 00 00 00 00 00 00 00 00 00 00   <- ON turned it off
```

So `off` commands get swallowed and `on` commands get sent twice, which on a toggle button means the light ends up back where it started.

## Why accepting the longer frame is not enough

The measurements in #3 show the frames agree on most fields but not all:

| | 9 byte frame | 13 byte frame |
|---|---|---|
| Fan Stufe 1 / 2 / 3 | byte 0 / 1 / 1 | same |
| Unterlicht | byte 4, 0x10 | same |
| **Deckenlicht** | **byte 5, 0x01** | **byte 9, 0x01** |

One flag has moved, and there is no reason to assume it is the last one that will. So instead of branching on the length in the decoder, the positions now live in layout tables and the length picks one:

```cpp
struct StatusBit { uint8_t index; uint8_t mask; };

struct StatusLayout {
  StatusBit fanStep1, fanStep2, fanStep3, fanPower;
  StatusBit lightUp, lightDown, lightCeiling;
  StatusBit nachlauf, movingUp, movingDown;
};
```

`decodeHoodStatus` reads every field through the table and knows no fixed offsets at all. A third model that shifts another flag is one more table plus one line in `statusLayout()`.

## What is measured and what is not

In the 13 byte layout only the three fan steps, the Unterlicht and the Deckenlicht come from real measurements. Oberlicht, Fan Power, Nachlauf and the two cover flags are carried over from the nine byte layout and are **not** confirmed on that frame. That is marked at the table and in a separate column in `REVERSE_ENGINEERING.md`, so the guesses stay visible and are one number each to correct.

An unknown frame length falls back to the short layout, whose indices stay inside the nine bytes every hood so far agrees on, rather than being decoded with another model's positions.

## Also in here

* `status_raw` publishes the frame at its real length instead of nine fixed bytes, so the next model can be read off the sensor without a serial cable.
* The buffer that `status_raw` is parsed back into on boot held 32 characters, too few for a 13 byte frame. That restore would have failed silently.
* `REVERSE_ENGINEERING.md` documents both layouts, and records the open question of how the original remote tells the models apart. Its buttons track the hood, so it must be making the same distinction somehow.

## Testing

47 unit tests pass, including the frames measured in #3 as vectors and the check that byte 5 is *not* read as Deckenlicht on a long frame. Builds for `esp32dev` and `esp32s3`. Running on my own hood, which sends nine bytes and decodes and publishes as before.

What I cannot test here is the case this actually fixes. That needs a hood that sends a longer frame, which is why this is a PR and not a commit on main.